### PR TITLE
CI: Remove deprecated runner images

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,20 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Has php5.6-8.0 and composer 2 pre-installed
-          # https://github.com/actions/virtual-environments/blob/ubuntu16/20210531.0/images/linux/Ubuntu1604-README.md
-          - os: ubuntu-16.04
-            php: "5.6"
-          # Has php7.1-8.0 and composer 2 pre-installed
-          # https://github.com/actions/virtual-environments/blob/ubuntu18/20210531.0/images/linux/Ubuntu1804-README.md
-          - os: ubuntu-18.04
-            php: "7.2"
-          - os: ubuntu-18.04
-            php: "7.3"
-          # Has php7.4-8.0 and composer 2 pre-installed
-          # https://github.com/actions/virtual-environments/blob/ubuntu20/20210531.0/images/linux/Ubuntu2004-README.md
+          # Has php7.4-8.2 and composer 2 pre-installed
+          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
           - os: ubuntu-20.04
             php: "7.4"
+
     # Use "PHP 0.0" as job name instead of "php (ubuntu-, 0.0)"
     name: PHP ${{ matrix.php }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
* Ubuntu 16.04 was removed in 2021 (actions/runner-images#3287)
* Ubuntu 18.04 will be removed in April (actions/runner-images#6002)